### PR TITLE
Clean up minor GCC 12.3 warnings

### DIFF
--- a/src/CMsg.cpp
+++ b/src/CMsg.cpp
@@ -85,7 +85,7 @@ void CMsg::reset_without_delete() {
 
 
 /* -------------------------------------------------------------------------- */
-CMsg::CMsg() : buf{nullptr}, dim{0}, payload_header{nullptr}, proto_dim{0}, tlv_size(esp_tlv_header_size) {
+CMsg::CMsg() : buf{nullptr}, dim{0}, proto_dim{0}, payload_header{nullptr}, tlv_size(esp_tlv_header_size) {
    
 }
 /* -------------------------------------------------------------------------- */
@@ -93,8 +93,8 @@ CMsg::CMsg() : buf{nullptr}, dim{0}, payload_header{nullptr}, proto_dim{0}, tlv_
 /* -------------------------------------------------------------------------- */
 CMsg::CMsg(uint16_t proto_size, bool use_tlv /*= true*/) : buf{nullptr}, 
                                                   dim{0}, 
-                                                  payload_header{nullptr}, 
-                                                  proto_dim{proto_size} {
+                                                  proto_dim{proto_size},
+                                                  payload_header{nullptr} {
 /* -------------------------------------------------------------------------- */      
    uint16_t request_size = 0;
    if(use_tlv) {
@@ -443,6 +443,7 @@ void CMsg::debug_print(const char* title) {
 /* -------------------------------------------------------------------------- */
 bool CMsg::store_rx_buffer(const uint8_t *buffer, uint32_t d) {
 /* -------------------------------------------------------------------------- */   
+   (void) d;
    /* rx_payload_len is TLV + PROTO (tlv can be present or not) */
    uint16_t rx_payload_len = verify_payload_header(buffer);
    


### PR DESCRIPTION
We build arduino-pico with `-Wall -Wextra -Werror`, and I would like to include this as part of our CI, so the 2 minor initialization warnings and single unused parameter need to be cleaned up.  There should be no functional changes.