### PR TITLE
Using DMA SPI transfers results in more than doubled network speed.

### DIFF
--- a/src/EspSpiDriver.cpp
+++ b/src/EspSpiDriver.cpp
@@ -333,7 +333,7 @@ int esp_host_send_and_receive(void) {
       SPIWIFI.beginTransaction(SPISettings(1000000ul * ESPHOSTSPI_MHZ, MSBFIRST, SPI_MODE2));
       digitalWrite(ESP_CS, LOW);
       delayMicroseconds(100);
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED) 
       SPIWIFI.transferAsync((const void *)esp32_spi_tx_buffer, (void *)esp32_spi_rx_buffer, MAX_SPI_BUFFER_SIZE);
       while (!SPIWIFI.finishedAsync());
 #else

--- a/src/EspSpiDriver.cpp
+++ b/src/EspSpiDriver.cpp
@@ -333,9 +333,14 @@ int esp_host_send_and_receive(void) {
       SPIWIFI.beginTransaction(SPISettings(1000000ul * ESPHOSTSPI_MHZ, MSBFIRST, SPI_MODE2));
       digitalWrite(ESP_CS, LOW);
       delayMicroseconds(100);
+#if defined(ARDUINO_ARCH_RP2040)
+      SPIWIFI.transferAsync((const void *)esp32_spi_tx_buffer, (void *)esp32_spi_rx_buffer, MAX_SPI_BUFFER_SIZE);
+      while (!SPIWIFI.finishedAsync());
+#else
       for (int i = 0; i < MAX_SPI_BUFFER_SIZE; i++) {
         esp32_spi_rx_buffer[i] = SPIWIFI.transfer(esp32_spi_tx_buffer[i]);
       }
+#endif
       digitalWrite(ESP_CS, HIGH);
       SPIWIFI.endTransaction();
 


### PR DESCRIPTION
For RP2040/RP2350 boards using the Arduino-Pico environment using DMA controller SPI transfer actually more than double the effective network speed.