### PR TITLE
Fix host hang when control requests are called with an unset/invalid Wifi mode

### DIFF
--- a/src/CCtrlWrapper.h
+++ b/src/CCtrlWrapper.h
@@ -561,7 +561,7 @@ public:
 
    /* ----------------------------------------------------------------------- */
    CMsg getMsg() {
-   /* ----------------------------------------------------------------------- */   
+   /* ----------------------------------------------------------------------- */
       int protobuf_len = ctrl_msg__get_packed_size(&request);
       CMsg msg(protobuf_len);
       if(msg.is_valid() && payload_set){
@@ -571,7 +571,11 @@ public:
          msg.set_payload_header(ESP_SERIAL_IF, 0);
          return msg;
       }
-      return CMsg(0);
+      /* default-constructed CMsg has is_valid()==false so the caller's
+         send_msg_to_esp will reject it and prepare_and_send_request will
+         return ESP_CONTROL_WRONG_REQUEST_INVALID_MSG instead of shipping
+         a zero-payload frame and blocking in wait_for_answer. */
+      return CMsg();
    }
 
    /* ----------------------------------------------------------------------- */

--- a/src/CEspControl.cpp
+++ b/src/CEspControl.cpp
@@ -587,6 +587,13 @@ int CEspControl::getWifiMacAddress(WifiMac_t& CAM, EspCallback_f cb) {
    Serial.println("[REQUEST] CEspControl::getWifiMacAddress");
    #endif
 
+   /* The device's get-MAC handler needs a concrete interface (STA or AP).
+      Reject WIFI_MODE_NONE up front so the caller gets a clear error rather
+      than a malformed request that the slave silently drops. */
+   if(CAM.mode <= WIFI_MODE_NONE || CAM.mode >= WIFI_MODE_MAX) {
+      return ESP_CONTROL_WRONG_REQUEST_INVALID_MSG;
+   }
+
    int rv = ESP_CONTROL_OK;
    CCtrlMsgWrapper req;
    prepare_and_send_request(CTRL_REQ_GET_MAC_ADDR, rv, &CAM, cb, req);
@@ -604,14 +611,18 @@ int CEspControl::setWifiMacAddress(WifiMac_t& CAM, EspCallback_f cb) {
    Serial.println("[REQUEST] CEspControl::setWifiMacAddress");
    #endif
 
+   if(CAM.mode <= WIFI_MODE_NONE || CAM.mode >= WIFI_MODE_MAX) {
+      return ESP_CONTROL_WRONG_REQUEST_INVALID_MSG;
+   }
+
    int rv = ESP_CONTROL_OK;
    /* message request preparation */
-   CCtrlMsgWrapper req; 
+   CCtrlMsgWrapper req;
    prepare_and_send_request(CTRL_REQ_SET_MAC_ADDR, rv, &CAM, cb, req);
    if(rv == ESP_CONTROL_OK) {
       rv = req.checkMacAddressSet();
    }
-   
+
    return rv;
 }
 

--- a/src/EspSpiDriver.cpp
+++ b/src/EspSpiDriver.cpp
@@ -333,7 +333,7 @@ int esp_host_send_and_receive(void) {
       SPIWIFI.beginTransaction(SPISettings(1000000ul * ESPHOSTSPI_MHZ, MSBFIRST, SPI_MODE2));
       digitalWrite(ESP_CS, LOW);
       delayMicroseconds(100);
-#if defined(ARDUINO_ARCH_RP2040)
+#if defined(ARDUINO_ARCH_RP2040) && !defined(ARDUINO_ARCH_MBED) 
       SPIWIFI.transferAsync((const void *)esp32_spi_tx_buffer, (void *)esp32_spi_rx_buffer, MAX_SPI_BUFFER_SIZE);
       while (!SPIWIFI.finishedAsync());
 #else

--- a/src/EspSpiDriver.cpp
+++ b/src/EspSpiDriver.cpp
@@ -333,9 +333,14 @@ int esp_host_send_and_receive(void) {
       SPIWIFI.beginTransaction(SPISettings(1000000ul * ESPHOSTSPI_MHZ, MSBFIRST, SPI_MODE2));
       digitalWrite(ESP_CS, LOW);
       delayMicroseconds(100);
+#if defined(ARDUINO_ARCH_RP2040)
+      SPIWIFI.transferAsync((const void *)esp32_spi_tx_buffer, (void *)esp32_spi_rx_buffer, MAX_SPI_BUFFER_SIZE);
+      while (!SPIWIFI.finishedAsync());
+#else
       for (int i = 0; i < MAX_SPI_BUFFER_SIZE; i++) {
         esp32_spi_rx_buffer[i] = SPIWIFI.transfer(esp32_spi_tx_buffer[i]);
       }
+#endif
       digitalWrite(ESP_CS, HIGH);
       SPIWIFI.endTransaction();
 


### PR DESCRIPTION
Calling CEspControl::getWifiMacAddress() (and other mode-guarded requests) before any setWifiMode() causes the host to block in wait_for_answer() until the 50 s timeout fires — with no log line, the call site appears to hang indefinitely.

When a guarded request builder (e.g. getWifiMacAddressMsg(mode)) is invoked with an out-of-range mode such as WIFI_MODE_NONE, the inner payload_set = true branch is skipped and getMsg() falls through to return CMsg(0);. That was intended as an "invalid message" sentinel, but CMsg(0) actually allocates a 26-byte buffer (12-byte esp_payload_header + 14-byte TLV header + 0-byte protobuf), zero-fills it, and reports is_valid() == true. send_msg_to_esp() accepts the frame and queues it for SPI TX. The slave receives a frame with len == 0 and silently drops it (correct slave-side behaviour), so no response ever comes back and the host blocks for the full timeout.